### PR TITLE
Prepare for real hardware

### DIFF
--- a/arch/x86_common/interrupt.cpp
+++ b/arch/x86_common/interrupt.cpp
@@ -59,8 +59,18 @@ extern "C" IrqContext* x86_irq_handler(IrqContext* ctx)
                 << ", data=" << (ctx->error & PF_CODE ? "n" : "y") << "\n";
       }
 
-      debug() << "(!!) exception #" << ctx->irq << " (" << strexcept(ctx->irq) << ")\n";
-      debug() << DEBUG_HEX << "rip=" << ctx->rip << ", rsp=" << ctx->rsp << ", err=" << ctx->error << "\n";
+      debug() << "(!!) exception #" << ctx->irq
+              << " (" << strexcept(ctx->irq) << ")\n";
+      debug() << DEBUG_HEX << "rip=" << ctx->rip
+              << ", rsp=" << ctx->rsp
+              << ", err=" << ctx->error << "\n";
+      debug() << DEBUG_HEX << "rax=" << ctx->rax
+              << ", rbx=" << ctx->rbx
+              << ", rcx=" << ctx->rcx << "\n";
+      debug() << DEBUG_HEX << "rdx=" << ctx->rdx
+              << ", rdi=" << ctx->rdi
+              << ", rsi=" << ctx->rsi << "\n";
+
       panic("unhandled exception");
     }
   }

--- a/arch/x86_common/start.cpp
+++ b/arch/x86_common/start.cpp
@@ -6,6 +6,7 @@
 #include <x86/stivale.h>
 #include <kernel_task.h>
 #include <features.h>
+#include <string.h>
 
 // setup stack allocation
 static const size_t SETUP_STACK_SIZE = 1024*16;
@@ -44,8 +45,13 @@ extern void create_page_bitmap();
 bool s_sseEnabled = false;
 bool s_avxEnabled = false;
 
+extern char _bss_start;
+extern char _bss_end;
+
 extern "C" void _NORETURN _start(struct stivale_struct *stivale)
 {
+  memset((void*)&_bss_start, 0, (size_t)_bss_end - (size_t)_bss_start);
+
   s_stivale = stivale;
   debug() << "Hello, world!\n";
 

--- a/kernel/debug_stream.cpp
+++ b/kernel/debug_stream.cpp
@@ -55,6 +55,7 @@ DebugStream& DebugStream::operator<<(const char* str)
 DebugStream& DebugStream::operator<<(char c)
 {
   *m_destPtr++ = c;
+  *m_destPtr = 0;
   return *this;
 }
 

--- a/kernel/include/libk/list.h
+++ b/kernel/include/libk/list.h
@@ -28,9 +28,14 @@ namespace ktl {
     class List : public Canary
     {
       public:
-        List() = default;
+        List()
+          : m_first(nullptr)
+          , m_last(nullptr)
+          , m_size(0)
+        { }
 
-        ~List() {
+        ~List()
+        {
           verify();
           clear();
         }
@@ -106,14 +111,15 @@ namespace ktl {
 
         T front() {
           verify();
-          assert(m_first && m_size > 0);
+          assert(m_size > 0);
+          assert(m_first != nullptr);
           return m_first->item;
         }
 
         T pop_front() {
           verify();
-          if (!m_first || m_size == 0)
-            assert(false);
+          assert(m_size > 0);
+          assert(m_first != nullptr);
           T item = m_first->item;
           remove(m_first);
           return item;

--- a/kernel/include/libk/vector.h
+++ b/kernel/include/libk/vector.h
@@ -10,7 +10,10 @@ namespace ktl {
   class vector
   {
     public:
-      vector() {
+      vector()
+        : m_size(0)
+        , m_array(nullptr)
+      {
         alloc(0);
       }
 
@@ -57,6 +60,7 @@ namespace ktl {
         T* old_array = m_array;
         alloc(capacity);
         memcpy(m_array, old_array, sizeof(T) * m_size);
+        delete old_array;
       }
 
     private:

--- a/kernel/mm/heap.cpp
+++ b/kernel/mm/heap.cpp
@@ -8,6 +8,7 @@
 #include <mm.h>
 #include <debug.h>
 #include <platform.h>
+#include <string.h>
 
 struct HeapBlock
 {
@@ -175,7 +176,11 @@ void *kmalloc(size_t size)
 
       crop(entry, required_size);
       s_heapMutex.unlock();
-      return entry + 1;
+
+      /* clear the memory before returning */
+      void* ret_ptr = (void*)(entry + 1);
+      memset(ret_ptr, 0, size);
+      return ret_ptr;
     }
   }
 
@@ -205,7 +210,10 @@ void *kmalloc(size_t size)
 
   s_heapMutex.unlock();
 
-  return blk + 1;
+  /* clear the memory before returning */
+  void* ret_ptr = (void*)(blk + 1);
+  memset(ret_ptr, 0, size);
+  return ret_ptr;
 }
 
 static void mergeBlocks(HeapBlock *first, HeapBlock *second)

--- a/kernel/sched/mutex.cpp
+++ b/kernel/sched/mutex.cpp
@@ -5,6 +5,7 @@
 
 Mutex::Mutex()
   : m_lock(0)
+  , m_heldBy(nullptr)
 { }
 
 Mutex::~Mutex()

--- a/kernel/user_proc.cpp
+++ b/kernel/user_proc.cpp
@@ -6,7 +6,8 @@
 
 UserProcess::UserProcess(ktl::shared_ptr<Loader> loader,
                          ktl::shared_ptr<Terminal> term)
-  : m_addrSpace(new AddrSpace())
+  : m_state(RUNNING)
+  , m_addrSpace(new AddrSpace())
   , m_loader(loader)
   , m_term(term)
 {

--- a/platform/pc/x86_64.ld
+++ b/platform/pc/x86_64.ld
@@ -46,10 +46,12 @@ SECTIONS
         *(.dynamic)
     } :data :dynamic
  
+    _bss_start = .;
     .bss : {
         *(COMMON)
         *(.bss*)
     } :data
+    _bss_end = .;
 
     . = ALIGN(4096);
     _kernel_end = .;


### PR DESCRIPTION
Tests on real hardware have shown that some parts of the code relies on memory to be initialized with zeroes, such as QEMU does. That's however not the case on bare metal, so the OS was crashing. Thankfully though, it came past the serial port initialization so sometimes (yes, there is still a race condition) you would get a page fault or protection fault with the corresponding addresses printed

The fixes make the OS boot successfully and launch the usermode program at least *sometimes*. There is still a race condition to be fixed!